### PR TITLE
CASH-2127 - Setup API Tools Package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,83 @@
+name: CI
+
+on: push
+
+jobs:
+    test:
+        name: Test
+
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: false
+            matrix:
+                dependencies:
+                    - lowest
+                    - highest
+                php-version:
+                    - '8.0'
+
+        steps:
+            # Setup
+            -   name: Checkout
+                uses: actions/checkout@v2
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    coverage: pcov
+                    ini-values: assert.exception=1, zend.assertions=1
+                    php-version: ${{ matrix.php-version}}
+                    tools: cs2pr
+
+            -   name: Cache Dependencies
+                uses: actions/cache@v2
+                with:
+                    path: |
+                        ~/.composer/cache
+                        vendor
+                    key: php-${{ matrix.php-version}}-${{ matrix.dependencies }}
+                    restore-keys: php-${{ matrix.php-version}}-${{ matrix.dependencies }}
+
+            -   name: Install Lowest Dependencies
+                if: ${{ 'lowest' == matrix.dependencies }}
+                run: composer update --prefer-lowest --no-interaction --no-progress
+
+            -   name: Install Highest Dependencies
+                if: ${{ 'highest' == matrix.dependencies }}
+                run: composer update --no-interaction --no-progress
+
+            # Test
+            -   name: Codestyle
+                run: php vendor/bin/phpcs --parallel=`nproc --all` -q --report=checkstyle | cs2pr
+
+            -   name: Psalm
+                run: php vendor/bin/psalm --threads=`nproc --all` --output-format=github --shepherd --stats
+
+            -   name: PHPUnit Checks Matcher
+                run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+            -   name: Unit Tests
+                run: |
+                    php vendor/bin/phpunit --coverage-text=coverage.txt --colors=never
+                    COVERAGE=$(php -r 'preg_match("#Lines:\s*(\d+.\d+)%#", file_get_contents("coverage.txt"), $out); echo $out[1];')
+                    echo "COVERAGE=${COVERAGE}" >> $GITHUB_ENV
+
+            -   name: Mutation Tests
+                run: |
+                    php vendor/bin/roave-infection-static-analysis-plugin --only-covered --show-mutations --threads=`nproc --all` --min-msi=100 --min-covered-msi=100 --no-progress > msi.txt
+                    cat msi.txt
+                    MSI=$(php -r 'preg_match("#\(MSI\):\s*([0-9.]+)%#", file_get_contents("msi.txt"), $out); echo $out[1];')
+                    echo "MSI=${MSI}" >> $GITHUB_ENV
+
+            # Report
+            -   name: Report PR Status
+                uses: actions/github-script@v3.1
+                with:
+                    github-token: ${{github.token}}
+                    script: |
+                        const msi = parseFloat(process.env.MSI);
+                        const coverage = parseFloat(process.env.COVERAGE);
+
+                        github.repos.createCommitStatus({...context.repo, sha: context.sha, state: msi > 95 ? 'success' : 'failure', context: 'Mutation Score Index', description: msi+'%'});
+                        github.repos.createCommitStatus({...context.repo, sha: context.sha, state: coverage > 99 ? 'success' : 'failure', context: 'Unit Test Coverage', description: coverage+'%'});

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+.idea
+.phpcs-cache
+.phpunit.result.cache
+/vendor/
+composer.lock
+infection.log
+phpcs.xml
+phpunit.xml
+psalm.xml

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,32 @@
+{
+    "name": "myonlinestore/api-tools",
+    "description": "Common API Tools",
+    "type": "library",
+    "license": "MIT",
+    "config": {
+        "sort-packages": true
+    },
+    "autoload": {
+        "psr-4": {
+            "MyOnlineStore\\ApiTools\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "MyOnlineStore\\ApiTools\\Tests\\": "tests/"
+        }
+    },
+    "require": {
+        "php": "^8.0",
+        "symfony/event-dispatcher": "^5.2",
+        "symfony/http-kernel": "^5.2"
+    },
+    "require-dev": {
+        "justinrainbow/json-schema": "^5.2.10",
+        "myonlinestore/coding-standard": "^3.1",
+        "phpunit/phpunit": "^9.5",
+        "roave/infection-static-analysis-plugin": "^1.7",
+        "thecodingmachine/safe": "^1.3",
+        "vimeo/psalm": "^4.7"
+    }
+}

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,0 +1,13 @@
+{
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "text": "infection.log"
+    },
+    "mutators": {
+        "@default": true
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg value="sp"/>
+
+    <file>src</file>
+    <file>tests</file>
+
+    <rule ref="MyOnlineStore"/>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
+<phpunit bootstrap="vendor/autoload.php"
+         cacheResultFile=".phpunit.result.cache"
+         colors="true"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<psalm errorLevel="1"
+       totallyTyped="true"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://getpsalm.org/schema/config"
+       xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="tests"/>
+
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <PropertyNotSetInConstructor>
+            <errorLevel type="suppress">
+                <directory name="tests"/>
+            </errorLevel>
+        </PropertyNotSetInConstructor>
+    </issueHandlers>
+</psalm>

--- a/src/Symfony/HttpKernel/EventSubscriber/JsonApiProblemResponse.php
+++ b/src/Symfony/HttpKernel/EventSubscriber/JsonApiProblemResponse.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace MyOnlineStore\ApiTools\Symfony\HttpKernel\EventSubscriber;
+
+use MyOnlineStore\ApiTools\Symfony\HttpKernel\Exception\JsonApiProblem;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class JsonApiProblemResponse implements EventSubscriberInterface
+{
+    public function __invoke(ExceptionEvent $event): void
+    {
+        $exception = $event->getThrowable();
+
+        if (!$exception instanceof JsonApiProblem) {
+            return;
+        }
+
+        $status = $exception->getStatusCode();
+
+        $event->setResponse(
+            new JsonResponse(
+                \array_merge(
+                    [
+                        'type' => $exception->getType(),
+                        'title' => $exception->getTitle(),
+                        'detail' => $exception->getDetail(),
+                        'status' => $status,
+                    ],
+                    $exception->getAdditionalInformation(),
+                ),
+                $status,
+            )
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::EXCEPTION => '__invoke'];
+    }
+}

--- a/src/Symfony/HttpKernel/Exception/JsonApiProblem.php
+++ b/src/Symfony/HttpKernel/Exception/JsonApiProblem.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace MyOnlineStore\ApiTools\Symfony\HttpKernel\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class JsonApiProblem extends HttpException
+{
+    /** @var array<array-key, mixed> */
+    private array $additionalInformation;
+    private string $detail;
+    private string $title;
+    private string $type;
+
+    /**
+     * @param array<array-key, mixed> $additionalInformation
+     */
+    public function __construct(
+        string $title,
+        string $detail,
+        int $statusCode = 500,
+        array $additionalInformation = [],
+        ?string $type = null,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct(
+            $statusCode,
+            $title,
+            $previous,
+            ['Content-Type' => 'application/json'],
+            $statusCode,
+        );
+
+        $this->title = $title;
+        $this->detail = $detail;
+        $this->additionalInformation = $additionalInformation;
+        $this->type = $type ?? 'https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html';
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function getAdditionalInformation(): array
+    {
+        return $this->additionalInformation;
+    }
+
+    public function getDetail(): string
+    {
+        return $this->detail;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+}

--- a/tests/Symfony/HttpKernel/EventSubscriber/JsonApiProblemResponseTest.php
+++ b/tests/Symfony/HttpKernel/EventSubscriber/JsonApiProblemResponseTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace MyOnlineStore\ApiTools\Tests\Symfony\HttpKernel\EventSubscriber;
+
+use MyOnlineStore\ApiTools\Symfony\HttpKernel\EventSubscriber\JsonApiProblemResponse;
+use MyOnlineStore\ApiTools\Symfony\HttpKernel\Exception\JsonApiProblem;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class JsonApiProblemResponseTest extends TestCase
+{
+    private JsonApiProblemResponse $jsonApiProblemResponse;
+
+    protected function setUp(): void
+    {
+        $this->jsonApiProblemResponse = new JsonApiProblemResponse();
+    }
+
+    public function testInvokeWithoutJsonApiProblem(): void
+    {
+        $exceptionEvent = new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $this->createMock(Request::class),
+            0,
+            $this->createMock(\Throwable::class)
+        );
+
+        $response = $exceptionEvent->getResponse();
+
+        ($this->jsonApiProblemResponse)($exceptionEvent);
+
+        self::assertSame($response, $exceptionEvent->getResponse());
+    }
+
+    public function testInvokeWithJsonApiProblem(): void
+    {
+        $jsonApiProblem = new JsonApiProblem(
+            'title',
+            'detail',
+            550,
+            ['foo' => 'bar'],
+            'type',
+        );
+
+        $exceptionEvent = new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $this->createMock(Request::class),
+            0,
+            $jsonApiProblem
+        );
+
+        $response = $exceptionEvent->getResponse();
+
+        ($this->jsonApiProblemResponse)($exceptionEvent);
+
+        self::assertNotSame($response, $exceptionEvent->getResponse());
+
+        self::assertEquals(
+            new JsonResponse(
+                \array_merge(
+                    [
+                        'type' => 'type',
+                        'title' => 'title',
+                        'detail' => 'detail',
+                        'status' => 550,
+                    ],
+                    ['foo' => 'bar'],
+                ),
+                550,
+            ),
+            $exceptionEvent->getResponse()
+        );
+    }
+
+    public function testGetSubscribedEvents(): void
+    {
+        self::assertEquals(
+            [KernelEvents::EXCEPTION => '__invoke'],
+            $this->jsonApiProblemResponse::getSubscribedEvents(),
+        );
+    }
+}

--- a/tests/Symfony/HttpKernel/Exception/JsonApiProblemTest.php
+++ b/tests/Symfony/HttpKernel/Exception/JsonApiProblemTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace MyOnlineStore\ApiTools\Tests\Symfony\HttpKernel\Exception;
+
+use MyOnlineStore\ApiTools\Symfony\HttpKernel\Exception\JsonApiProblem;
+use PHPUnit\Framework\TestCase;
+
+final class JsonApiProblemTest extends TestCase
+{
+    public function testAccessorsWithMinimalVariables(): void
+    {
+        $title = 'title';
+        $detail = 'detail';
+
+        $jsonApiProblem = new JsonApiProblem($title, $detail);
+
+        self::assertEquals($title, $jsonApiProblem->getTitle());
+        self::assertEquals($detail, $jsonApiProblem->getDetail());
+        self::assertEquals(500, $jsonApiProblem->getStatusCode());
+        self::assertEquals(500, $jsonApiProblem->getCode());
+        self::assertEquals([], $jsonApiProblem->getAdditionalInformation());
+        self::assertEquals('https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html', $jsonApiProblem->getType());
+        self::assertEquals(['Content-Type' => 'application/json'], $jsonApiProblem->getHeaders());
+        self::assertNull($jsonApiProblem->getPrevious());
+    }
+
+    public function testAccessorsWithMaximalVariables(): void
+    {
+        $title = 'title';
+        $detail = 'detail';
+        $statusCode = 400;
+        $additionalInformation = ['foo', 'bar'];
+        $type = 'type';
+        $throwable = $this->createMock(\Throwable::class);
+
+        $jsonApiProblem = new JsonApiProblem($title, $detail, $statusCode, $additionalInformation, $type, $throwable);
+
+        self::assertEquals($title, $jsonApiProblem->getTitle());
+        self::assertEquals($detail, $jsonApiProblem->getDetail());
+        self::assertEquals($statusCode, $jsonApiProblem->getStatusCode());
+        self::assertEquals($statusCode, $jsonApiProblem->getCode());
+        self::assertEquals($additionalInformation, $jsonApiProblem->getAdditionalInformation());
+        self::assertEquals($type, $jsonApiProblem->getType());
+        self::assertEquals(['Content-Type' => 'application/json'], $jsonApiProblem->getHeaders());
+        self::assertSame($throwable, $jsonApiProblem->getPrevious());
+    }
+}


### PR DESCRIPTION
Introduces a `JsonApiProblem` http exception and corresponding listener, allowing to easily return an [RFC 7807](https://tools.ietf.org/html/rfc7807) response.

Can be submitted to Packagist once merged.