### PR TITLE
chore: Added support for PHP 7.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
                     - lowest
                     - highest
                 php-version:
+                    - '7.4'
                     - '8.0'
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "type": "library",
     "license": "MIT",
     "config": {
-        "sort-packages": true,
         "platform": {
             "php": "7.4.7"
-        }
+        },
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,6 @@
     "type": "library",
     "license": "MIT",
     "config": {
-        "platform": {
-            "php": "7.4.7"
-        },
         "sort-packages": true
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,10 @@
     "type": "library",
     "license": "MIT",
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "platform": {
+            "php": "7.4.7"
+        }
     },
     "autoload": {
         "psr-4": {
@@ -17,7 +20,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^7.4.7|^8.0",
         "symfony/event-dispatcher": "^5.2",
         "symfony/http-kernel": "^5.2"
     },
@@ -25,7 +28,7 @@
         "justinrainbow/json-schema": "^5.2.10",
         "myonlinestore/coding-standard": "^3.1",
         "phpunit/phpunit": "^9.5",
-        "roave/infection-static-analysis-plugin": "^1.7",
+        "roave/infection-static-analysis-plugin": "^1.16",
         "thecodingmachine/safe": "^1.3",
         "vimeo/psalm": "^4.7"
     }

--- a/src/Symfony/HttpKernel/Exception/JsonApiProblem.php
+++ b/src/Symfony/HttpKernel/Exception/JsonApiProblem.php
@@ -22,7 +22,7 @@ final class JsonApiProblem extends HttpException
         int $statusCode = 500,
         array $additionalInformation = [],
         ?string $type = null,
-        ?\Throwable $previous = null,
+        ?\Throwable $previous = null
     ) {
         parent::__construct(
             $statusCode,


### PR DESCRIPTION
These classes will be used in an upcoming payment service change, which still runs on 7.4.