### PR TITLE
security: Bump `cuyz/valinor` to `^0.7.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "^7.4.7|^8.0",
-        "cuyz/valinor": "^0.6.0",
+        "cuyz/valinor": "^0.7.0",
         "sensio/framework-extra-bundle": "^5.6",
         "symfony/event-dispatcher": "^5.2",
         "symfony/http-kernel": "^5.2"
@@ -35,6 +35,6 @@
         "psalm/plugin-phpunit": "^0.16.1",
         "psalm/plugin-symfony": "^3.1",
         "roave/infection-static-analysis-plugin": "^1.18",
-        "vimeo/psalm": "^4.7"
+        "vimeo/psalm": "^4.22"
     }
 }

--- a/tests/Symfony/Request/ParamConverter/StubValinorBodyJsonConverter.php
+++ b/tests/Symfony/Request/ParamConverter/StubValinorBodyJsonConverter.php
@@ -24,6 +24,6 @@ final class StubValinorBodyJsonConverter extends ValinorParamConverter
     protected function getMapperBuilder(): MapperBuilder
     {
         return parent::getMapperBuilder()
-            ->bind(static fn (string $id): StubId => StubId::fromString($id));
+            ->registerConstructor([StubId::class, 'fromString']);
     }
 }

--- a/tests/Symfony/Request/ParamConverter/StubValinorParamConverter.php
+++ b/tests/Symfony/Request/ParamConverter/StubValinorParamConverter.php
@@ -27,6 +27,6 @@ final class StubValinorParamConverter extends ValinorParamConverter
     protected function getMapperBuilder(): MapperBuilder
     {
         return parent::getMapperBuilder()
-            ->bind(static fn (string $id): StubId => StubId::fromString($id));
+            ->registerConstructor([StubId::class, 'fromString']);
     }
 }


### PR DESCRIPTION
Missed it in the review of https://github.com/MyOnlineStore/api-tools/pull/5, but Valinor should be bumped to `^0.7`