### PR TITLE
fix: Updated valinor package to >=0.12 to obtain security fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "^8.0",
-        "cuyz/valinor": "^0.8.0",
+        "cuyz/valinor": "^0.13",
         "sensio/framework-extra-bundle": "^6.2",
         "symfony/event-dispatcher": "^5.4 || ^6.0",
         "symfony/http-kernel": "^5.4 || ^6.0"

--- a/src/Symfony/HttpKernel/Exception/JsonApiProblem.php
+++ b/src/Symfony/HttpKernel/Exception/JsonApiProblem.php
@@ -50,7 +50,8 @@ final class JsonApiProblem extends HttpException
         $flattenedMessages = (new MessagesFlattener($mappingError->node()))->errors();
 
         foreach ($flattenedMessages as $message) {
-            $errors[\str_replace(\sprintf('.%s', $message->name()), '', $message->path())] = $message->__toString();
+            $messageNode = $message->node();
+            $errors[\str_replace(\sprintf('.%s', $messageNode->name()), '', $messageNode->path())] = $message->body();
         }
 
         return new self($title, $detail, $statusCode, ['errors' => $errors]);

--- a/tests/Symfony/Request/ParamConverter/ValinorParamConverterTest.php
+++ b/tests/Symfony/Request/ParamConverter/ValinorParamConverterTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
 
-final class ValinorParameterConverterTest extends TestCase
+final class ValinorParamConverterTest extends TestCase
 {
     private StubValinorParamConverter $converter;
 
@@ -53,7 +53,7 @@ final class ValinorParameterConverterTest extends TestCase
             self::assertEquals(
                 [
                     'errors' => [
-                        '' => 'Expected a different value than "".',
+                        '*root*' => 'Expected a different value than "".',
                     ],
                 ],
                 $exception->getAdditionalInformation()


### PR DESCRIPTION
Valinor version `0.12` includes a [security patch](https://github.com/CuyZ/Valinor/releases/tag/0.12.0) that is now required by `roave/security-advisories`, so I updated `cuzy/valinor` to the latest version (`0.13`).

I whitelisted the `InvalidArgumentException` exception of the `webmozart\assert` in our base Valinor param converter, so that any assertions made using the Webmozart package will come through by default. Other exceptions will have to be added manually in the applications using the api-tools package.