### PR TITLE
feat(MOS-854): Added support for PHP 8.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
             -   uses: actions/checkout@v3
             -   uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.0
+                    php-version: 8.2
                     coverage: none
             -   uses: ramsey/composer-install@v2
             -   id: set-php-versions

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "myonlinestore/coding-standard": "^3.1",
-        "myonlinestore/php-devtools": "dev-MOS-855-add-php82-support",
+        "myonlinestore/php-devtools": "^0.4",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.16.1",
         "psalm/plugin-symfony": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -22,18 +22,18 @@
     },
     "require": {
         "php": "^8.0",
-        "cuyz/valinor": "^0.13",
+        "cuyz/valinor": "^1.5",
         "sensio/framework-extra-bundle": "^6.2",
         "symfony/event-dispatcher": "^5.4 || ^6.0",
         "symfony/http-kernel": "^5.4 || ^6.0"
     },
     "require-dev": {
         "myonlinestore/coding-standard": "^3.1",
-        "myonlinestore/php-devtools": "^0.3.0",
+        "myonlinestore/php-devtools": "dev-MOS-855-add-php82-support",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.16.1",
-        "psalm/plugin-symfony": "^3.1",
+        "psalm/plugin-symfony": "^4.0",
         "roave/infection-static-analysis-plugin": "^1.18",
-        "vimeo/psalm": "^4.23"
+        "vimeo/psalm": "^4.30"
     }
 }

--- a/src/Symfony/HttpKernel/Exception/JsonApiProblem.php
+++ b/src/Symfony/HttpKernel/Exception/JsonApiProblem.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace MyOnlineStore\ApiTools\Symfony\HttpKernel\Exception;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\Mapper\Tree\Message\MessagesFlattener;
+use CuyZ\Valinor\Mapper\Tree\Message\Messages;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 final class JsonApiProblem extends HttpException
@@ -47,7 +47,7 @@ final class JsonApiProblem extends HttpException
         int $statusCode = 422
     ): self {
         $errors = [];
-        $flattenedMessages = (new MessagesFlattener($mappingError->node()))->errors();
+        $flattenedMessages = Messages::flattenFromNode($mappingError->node());
 
         foreach ($flattenedMessages as $message) {
             $node = $message->node();

--- a/tests/Symfony/Request/ParamConverter/StubId.php
+++ b/tests/Symfony/Request/ParamConverter/StubId.php
@@ -7,11 +7,13 @@ use Webmozart\Assert\Assert;
 
 final class StubId
 {
+    /** @psalm-pure */
     private function __construct(
         private string $id,
     ) {
     }
 
+    /** @psalm-pure */
     public static function fromString(string $id): self
     {
         Assert::stringNotEmpty($id);

--- a/tests/Symfony/Request/ParamConverter/StubValinorBodyJsonConverter.php
+++ b/tests/Symfony/Request/ParamConverter/StubValinorBodyJsonConverter.php
@@ -24,6 +24,9 @@ final class StubValinorBodyJsonConverter extends ValinorParamConverter
     protected function getMapperBuilder(): MapperBuilder
     {
         return parent::getMapperBuilder()
-            ->registerConstructor(static fn (string $id): StubId => StubId::fromString($id));
+            ->registerConstructor(
+                /** @psalm-pure  */
+                static fn (string $id): StubId => StubId::fromString($id)
+            );
     }
 }


### PR DESCRIPTION
Depends on:
- [x] https://github.com/MyOnlineStore/php-devtools/pull/10 (pin from dev branch to `^0.4` once merged)

Changes:
- Updated `cuyz/valinor` from 0.13 to 1.5 by walking through the per-version [upgrade guide](https://valinor.cuyz.io/latest/project/changelog/).
- Updated `psalm/plugin-symfony` which was imcompatible with the new  `cuyz/valinor` version

**Don't forget to add a new `2.3` tag after merging, so the new version can be accurately pinned in other projects.**