### PR TITLE
chore(MOS-1819): Add PHP 8.3 support.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
             -   uses: actions/checkout@v3
             -   uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.2
+                    php-version: 8.3
                     coverage: none
             -   uses: ramsey/composer-install@v2
             -   id: set-php-versions

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "myonlinestore/coding-standard": "^3.1",
-        "myonlinestore/php-devtools": "dev-MOS-1820-php-83",
+        "myonlinestore/php-devtools": "^0.5",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.19",
         "psalm/plugin-symfony": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,11 @@
     },
     "require-dev": {
         "myonlinestore/coding-standard": "^3.1",
-        "myonlinestore/php-devtools": "^0.4",
+        "myonlinestore/php-devtools": "dev-MOS-1820-php-83",
         "phpunit/phpunit": "^9.5",
-        "psalm/plugin-phpunit": "^0.16.1",
-        "psalm/plugin-symfony": "^4.0",
+        "psalm/plugin-phpunit": "^0.19",
+        "psalm/plugin-symfony": "^5.0",
         "roave/infection-static-analysis-plugin": "^1.18",
-        "vimeo/psalm": "^4.30"
+        "vimeo/psalm": "^5.0"
     }
 }


### PR DESCRIPTION
## ⚠️ Before merging.
- [x] https://github.com/MyOnlineStore/php-devtools/pull/13
- [x] Update `myonlinestore/php-devtools` version to `^0.5` in `composer.json`.

## 💅🏻  Aftercare.
- [x] Add a new release tag, ~`2.5`.~ `2.4`

## 🌟 Summary.
This pull request adds PHP 8.3 support and updates the Psalm version.

## 📝 Changelog.
- Changed GitHub workflow PHP version to `8.3`.
- Updated `vimeo/psalm` to `^5.0`.
- Updated `myonlinestore/php-devtools` to latest version.