### PR TITLE
chore: Also wrap non-Valinor mapping related exceptions

### DIFF
--- a/src/Symfony/Request/ParamConverter/ValinorParamConverter.php
+++ b/src/Symfony/Request/ParamConverter/ValinorParamConverter.php
@@ -36,7 +36,8 @@ abstract class ValinorParamConverter implements ParamConverterInterface
             throw new JsonApiProblem(
                 'Invalid Request',
                 $this->debug ? $exception->getMessage() : 'Invalid data provided.',
-                422
+                422,
+                previous: $exception,
             );
         }
 
@@ -59,7 +60,7 @@ abstract class ValinorParamConverter implements ParamConverterInterface
     {
         $mapperBuilder = (new MapperBuilder())
             ->filterExceptions(
-                /** @psalm-pure  */
+            /** @psalm-pure */
                 static function (\Throwable $exception) {
                     if ($exception instanceof InvalidArgumentException) {
                         /** @psalm-suppress ImpureMethodCall */


### PR DESCRIPTION
## Postrequisites
- [x] Tag a new release after merge

## Summary
Also wrap non-Valinor mapping exceptions in the `JsonApiProblem` exception that is thrown if Valinor mapping fails. This allows the application using this library to use this information, like for logging purposes.